### PR TITLE
Fix path to config file in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Once you have your data in the DB, I recommend using a SQLite browser like [SQLi
 ## Releases
 
 GarminDB requires [Python](https://www.python.org/). With Python installed, install the latest release with [pip](https://pypi.org/project/pip/) by running `pip install garmindb` in a terminal.
-* Copy `GarminConnectConfig.json.example` to `~/.garmindb/GarminConnectConfig.json`, edit it, and add your Garmin Connect username and password and adjust the start dates to match the dats of your data in Garmin Connect.
+* Copy `GarminConnectConfig.json.example` to `~/.GarminDb/GarminConnectConfig.json`, edit it, and add your Garmin Connect username and password and adjust the start dates to match the dats of your data in Garmin Connect.
 * Starting out: download all of your data and create your db by running `garmindb_cli.py --all --download --import --analyze` in a terminal.
 * Incrementally update your db by downloading the latest data and importing it by running `garmindb_cli.py --all --download --import --analyze --latest` in a terminal.
 * Ocassionally run `garmin_cli.py --backup` to backup your DB files.
@@ -37,7 +37,7 @@ The scripts are automated with [Make](https://www.gnu.org/software/make/manual/m
 
 * Git clone GarminDB repo using the [SSH clone method](https://github.com/git-guides/git-clone#git-clone-with-ssh). The submodules require you to use SSH and not HTTPS. Get the command from the green button on the project home page.
 * Run `make setup` in the cloned tree to get the scripts ready to process data.
-* Copy `GarminConnectConfig.json.example` to `~/.garmindb/GarminConnectConfig.json`, edit it, and add your Garmin Connect username and password and adjust the start dates to match the dats of your data in Garmin Connect.
+* Copy `GarminConnectConfig.json.example` to `~/.GarminDb/GarminConnectConfig.json`, edit it, and add your Garmin Connect username and password and adjust the start dates to match the dats of your data in Garmin Connect.
 * Run `make create_dbs` once to fetch and process for you data.
 * Keep all of your local data up to date by periodically running only one command: `make`.
 


### PR DESCRIPTION
The directory looked for is called GarminDb per default:
https://github.com/tcgoetz/GarminDB/blob/cf134d60f3e81224ee2978cb8908de03e9cc747e/garmindb/config.py#L17