### PR TITLE
Add sleep score and qualifier

### DIFF
--- a/garmindb/garmindb/garmin_db.py
+++ b/garmindb/garmindb/garmin_db.py
@@ -225,7 +225,7 @@ class Sleep(GarminDb.Base, idbutils.DbObject):
     __tablename__ = 'sleep'
 
     db = GarminDb
-    table_version = 2
+    table_version = 3
 
     day = Column(Date, primary_key=True)
     start = Column(DateTime)
@@ -238,6 +238,8 @@ class Sleep(GarminDb.Base, idbutils.DbObject):
     avg_spo2 = Column(Float)
     avg_rr = Column(Float)
     avg_stress = Column(Float)
+    score = Column(Integer)
+    qualifier = Column(String)
 
     @classmethod
     def get_stats(cls, session, start_ts, end_ts):

--- a/garmindb/import_monitoring.py
+++ b/garmindb/import_monitoring.py
@@ -183,6 +183,15 @@ class GarminSleepData(JsonFileProcessor):
         else:
             root_logger.info("Importing %s without REM data and UTC offset %r", day, utc_offset)
             sleep_activity_levels = SleepActivityLevels
+        score = None
+        qualifier = None
+        try:
+            sleep_core_overall = daily_sleep.get('sleepScores').get('overall')
+            score = sleep_core_overall.get('value')
+            qualifier = sleep_core_overall.get('qualifierKey')
+        except AttributeError:
+            root_logger.warn("Could not get sleep score for %s", day)
+
         day_data = {
             'day': day,
             'start': daily_sleep.get('sleepStartTimestampGMT'),
@@ -194,7 +203,9 @@ class GarminSleepData(JsonFileProcessor):
             'awake': daily_sleep.get('awakeSleepSeconds'),
             'avg_spo2': daily_sleep.get('averageSpO2Value'),
             'avg_rr': daily_sleep.get('averageRespirationValue'),
-            'avg_stress': daily_sleep.get('avgSleepStress')
+            'avg_stress': daily_sleep.get('avgSleepStress'),
+            'score': score,
+            'qualifier': qualifier
         }
         Sleep.insert_or_update(self.garmin_db, day_data, ignore_none=True)
         sleep_levels = json_data.get('sleepLevels')


### PR DESCRIPTION
It's my first contribution to the project so please tell me if I did anything wrong :)

This is a simple PR to add 2 more fields to the sleep table : score and qualifier, as they are fields I find useful.

I tested it with an Epix Gen 2 and it works fine. If the data is not provided for other watches, the field will just be set to None