### PR TITLE
Fix ConfigManager.default_display_activities()

### DIFF
--- a/garmindb/config_manager.py
+++ b/garmindb/config_manager.py
@@ -265,4 +265,4 @@ class ConfigManager(Config):
     @classmethod
     def default_display_activities(cls):
         """Return a list of the default activities to display."""
-        return [Sport.strict_from_string(activity) for activity in cls.default_display_activities]
+        return [Sport.strict_from_string(activity) for activity in super().default_display_activities]


### PR DESCRIPTION
cls.default_display_activities could not work because the name in the base class was overridden.

Fix #154

Before
```
(.venv) $ ipython
Python 3.10.6 (main, Mar 10 2023, 10:55:28) [GCC 11.3.0]
IPython 8.13.2 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from garmindb import ConfigManager

In [2]: ConfigManager.default_display_activities()
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[2], line 1
----> 1 ConfigManager.default_display_activities()

File ~/coding/GarminDB/garmindb/config_manager.py:268, in
ConfigManager.default_display_activities(cls)
    265 @classmethod
    266 def default_display_activities(cls):
    267     """Return a list of the default activities to display."""
--> 268     return [Sport.strict_from_string(activity) for activity in
cls.default_display_activities]

TypeError: 'method' object is not iterable
```

After
```
In [2]: ConfigManager.default_display_activities()
Out[2]: [<Sport.walking: 11>, <Sport.running: 1>, <Sport.cycling: 2>]
```