### PR TITLE
Update GarminConnectConfig.json.example to make date format more explicit

### DIFF
--- a/garmindb/GarminConnectConfig.json.example
+++ b/garmindb/GarminConnectConfig.json.example
@@ -5,10 +5,10 @@
         "password"                      : "yourpassword"
     },
     "data": {
-        "weight_start_date"             : "01/01/2019",
-        "sleep_start_date"              : "01/01/2019",
-        "rhr_start_date"                : "01/01/2019",
-        "monitoring_start_date"         : "01/01/2019",
+        "weight_start_date"             : "12/31/2019",
+        "sleep_start_date"              : "12/31/2019",
+        "rhr_start_date"                : "12/31/2019",
+        "monitoring_start_date"         : "12/31/2019",
         "download_latest_activities"    : 25,
         "download_all_activities"       : 1000
     },


### PR DESCRIPTION
It's hard for us Europeans to guess the correct date format, this makes it explicit :).