### PR TITLE
feat: optional stat_end_date in config

### DIFF
--- a/garmindb/garmin_connect_config_manager.py
+++ b/garmindb/garmin_connect_config_manager.py
@@ -213,9 +213,10 @@ class GarminConnectConfigManager(JsonConfig):
 
     def stat_start_date(self, stat_type):
         """Return a tuple containing the start date and the number of days to fetch stats from."""
-        date = self.get_node_value('data', stat_type + '_start_date')
-        days = (datetime.datetime.now().date() - date).days
-        return (date, days)
+        start_date = self.get_node_value('data', stat_type + '_start_date')
+        end_date = self.get_node_value_default('data', stat_type + '_end_date', datetime.datetime.now().date())
+        days = (end_date - start_date).days
+        return (start_date, days)
 
     def device_mount_dir(self):
         """Return the directory where the Garmin USB device is mounted."""


### PR DESCRIPTION
Enables users to add an `end_date` for each stat type in the config file. I was personally trying to achieve this and I think it would be a useful feature!