### PR TITLE
build: using external references for git submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,12 @@
 [submodule "Fit"]
 	path = Fit
-	url = ../Fit.git
+	url = "https://github.com/tcgoetz/Fit.git"
 [submodule "utilities"]
 	path = utilities
-	url = ../utilities.git
+	url = "https://github.com/tcgoetz/utilities.git"
 [submodule "Tcx"]
 	path = Tcx
-	url = ../Tcx.git
+	url = "https://github.com/tcgoetz/Tcx.git"
 [submodule "Plugins"]
 	path = Plugins
-	url = ../GarminDbPlugins.git
+	url = "https://github.com/tcgoetz/GarminDbPlugins.git"


### PR DESCRIPTION
- Allows for use of tcgoetz submodules in forked GarminDB repos