### PR TITLE
Add analyzer backfill of daily Sleep from FIT SleepEvents; include sleep-only days

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -1,2 +1,3 @@
 Tom Goetz
 William Baum
+Mike Bazzell

--- a/garmindb/garmindb/garmin_db.py
+++ b/garmindb/garmindb/garmin_db.py
@@ -287,12 +287,15 @@ class SleepEvents(GarminDb.Base, idbutils.DbObject):
     @classmethod
     def get_day_stats(cls, session, day_date):
         """Return a dictionary of aggregate statistics for the given time period."""
-        deep_sleep = cls.get_level_time(cls, session, day_date, 'deep_sleep')
-        light_sleep = cls.get_level_time(cls, session, day_date, 'light_sleep')
-        rem_sleep = cls.get_level_time(cls, session, day_date, 'rem_sleep')
-        awake = cls.get_level_time(cls, session, day_date, 'awake')
+        deep_sleep = cls.get_level_time(session, day_date, 'deep_sleep')
+        light_sleep = cls.get_level_time(session, day_date, 'light_sleep')
+        rem_sleep = cls.get_level_time(session, day_date, 'rem_sleep')
+        awake = cls.get_level_time(session, day_date, 'awake')
+        total_sleep = fitfile.conversions.add_time(
+            fitfile.conversions.add_time(deep_sleep, light_sleep), rem_sleep
+        )
         return {
-            'total_sleep': deep_sleep + light_sleep + rem_sleep,
+            'total_sleep': total_sleep,
             'deep_sleep': deep_sleep,
             'light_sleep': light_sleep,
             'rem_sleep': rem_sleep,

--- a/garmindb/version_info.py
+++ b/garmindb/version_info.py
@@ -9,7 +9,7 @@ python_required = (3, 10, 0)
 dev_python_required = (3, 13, 5)
 python_tested = (3, 13, 5)
 version_info = (3, 6, 5)
-prerelease = True
+prerelease = False
 
 
 def version_string():

--- a/garmindb/version_info.py
+++ b/garmindb/version_info.py
@@ -9,7 +9,7 @@ python_required = (3, 10, 0)
 dev_python_required = (3, 13, 5)
 python_tested = (3, 13, 5)
 version_info = (3, 6, 5)
-prerelease = False
+prerelease = True
 
 
 def version_string():


### PR DESCRIPTION
When only FIT sleep files are available (no Garmin Connect JSON), the sleep table remained empty even though sleep_events had data. This PR adds an analysis-time backfill that synthesizes daily Sleep rows from SleepEvents and ensures the analyzer processes days/years that only contain sleep data. Not all rows are filled (e.g. avg_spo2, avg_rr, avg_stress, score, and qualifier are all NULL) but other summaries are there.

To test, connect the device and run with either the full array of options or just `--analyze`
