### PR TITLE
Feature/hrv support

### DIFF
--- a/garmindb/garmindb/__init__.py
+++ b/garmindb/garmindb/__init__.py
@@ -8,7 +8,7 @@ __license__ = "GPL"
 
 from .garmin_db import GarminDb, Attributes, Device, DeviceInfo, File, Weight, Stress, Sleep, SleepEvents, RestingHeartRate, DailySummary
 from .monitoring_db import MonitoringDb, MonitoringInfo, MonitoringHeartRate, MonitoringIntensity, MonitoringClimb, Monitoring, \
-    MonitoringRespirationRate, MonitoringPulseOx
+    MonitoringRespirationRate, MonitoringPulseOx, MonitoringHrvValue, MonitoringHrvStatus
 from .activities_db import ActivitiesDb, Activities, ActivityLaps, ActivityRecords, ActivitiesDevices, ActivitySplits, SportActivities, StepsActivities, \
     PaddleActivities, CycleActivities, ClimbingActivities
 from .garmin_summary_db import GarminSummaryDb, Summary, YearsSummary, MonthsSummary, WeeksSummary, DaysSummary, IntensityHR

--- a/garmindb/import_monitoring.py
+++ b/garmindb/import_monitoring.py
@@ -72,7 +72,7 @@ class GarminMonitoringFitData(FitData):
         debug (Boolean): enable debug logging
 
         """
-        super().__init__(input_dir, debug, latest, True, [fitfile.FileType.monitoring_b], measurement_system)
+        super().__init__(input_dir, debug, latest, True, [fitfile.FileType.monitoring_b, fitfile.FileType.hrv_status], measurement_system)
 
 
 class GarminSleepFitData(FitData):

--- a/garmindb/version_info.py
+++ b/garmindb/version_info.py
@@ -9,7 +9,7 @@ python_required = (3, 10, 0)
 dev_python_required = (3, 13, 5)
 python_tested = (3, 13, 5)
 version_info = (3, 6, 6)
-prerelease = True
+prerelease = False
 
 
 def version_string():

--- a/garmindb/version_info.py
+++ b/garmindb/version_info.py
@@ -9,7 +9,7 @@ python_required = (3, 10, 0)
 dev_python_required = (3, 13, 9)
 python_tested = (3, 13, 9)
 version_info = (3, 6, 7)
-prerelease = False
+prerelease = True
 
 
 def version_string():


### PR DESCRIPTION
## Add HRV (Heart Rate Variability) Data Support

This PR adds support for importing HRV data from Garmin's `HRV_STATUS.fit` files.

### Changes

**Database:**
- Add `MonitoringHrvValue` table for individual RMSSD readings during sleep
- Add `MonitoringHrvStatus` table for daily HRV status summaries
- Bump monitoring DB version to 7

**Processing:**
- Add HRV message handlers in `MonitoringFitFileProcessor`
- Include `FileType.hrv_status` (68) in monitoring FIT file processing

### HRV Data Captured

| Field | Description |
|-------|-------------|
| `hrv` | Individual RMSSD reading (ms) |
| `weekly_average` | 7-day average RMSSD |
| `last_night` | Last night's average RMSSD |
| `baseline_low/high` | Personal baseline bounds |
| `status` | 0=unknown, 2=poor, 3=low, 4=balanced |
| `reading_count` | Number of readings |

### Dependencies
Requires PR to Fit submodule: [link to Fit PR](https://github.com/tcgoetz/Fit/pull/5)

### Testing
Tested with 1,016 HRV_STATUS.fit files spanning 2+ years of data.