### PR TITLE
Retry much more persistently

### DIFF
--- a/garmindb/download.py
+++ b/garmindb/download.py
@@ -54,7 +54,12 @@ class Download():
         self.gc_config = gc_config
         self.garth_session_file = self.gc_config.get_session_file()
         self.garth = GarthClient()
-        self.garth.configure(domain=self.gc_config.get_garmin_base_domain())
+        self.garth.configure(
+            domain=self.gc_config.get_garmin_base_domain(),
+            timeout=30,
+            retries=10,
+            backoff_factor=1.5,
+        )
 
     def __resume_session(self):
         if os.path.isfile(self.garth_session_file):
@@ -174,7 +179,7 @@ class Download():
         try:
             self.save_binary_file(zip_filename, url)
         except GarthHTTPError as e:
-            root_logger.error("Exception getting daily summary: %s", e)
+            root_logger.error("Exception getting monitoring data: %s", e)
 
     def get_monitoring(self, directory_func, date, days):
         """Download the daily monitoring data from Garmin Connect, unzip and save the raw files."""
@@ -199,7 +204,7 @@ class Download():
         try:
             self.save_json_to_file(json_filename, self.garth.connectapi(self.garmin_connect_weight_url, params=params), overwrite)
         except GarthHTTPError as e:
-            root_logger.error("Exception getting daily summary: %s", e)
+            root_logger.error("Exception getting weight data: %s", e)
 
     def get_weight(self, directory, date, days, overwrite):
         """Download the sleep data from Garmin Connect and save to a JSON file."""
@@ -280,7 +285,7 @@ class Download():
         try:
             self.save_json_to_file(json_filename, self.garth.connectapi(url, params=params), overwrite)
         except GarthHTTPError as e:
-            root_logger.error("Exception getting daily summary: %s", e)
+            root_logger.error("Exception getting sleep data: %s", e)
 
     def get_sleep(self, directory, date, days, overwrite):
         """Download the sleep data from Garmin Connect and save to a JSON file."""
@@ -300,7 +305,7 @@ class Download():
             self.save_json_to_file(json_filename, self.garth.connectapi(
                 url, params=params), overwrite)
         except GarthHTTPError as e:
-            root_logger.error("Exception getting daily summary %s", e)
+            root_logger.error("Exception getting rhr data: %s", e)
 
     def get_rhr(self, directory, date, days, overwrite):
         """Download the resting heart rate data from Garmin Connect and save to a JSON file."""
@@ -328,7 +333,7 @@ class Download():
         try:
             self.save_json_to_file(json_filename, self.garth.connectapi(url), overwrite)
         except GarthHTTPError as e:
-            root_logger.error("Exception getting daily summary %s", e)
+            root_logger.error("Exception getting hrv data: %s", e)
 
     def get_hrv(self, directory, date, days, overwrite):
         """Download the heart rate variability (HRV) data from Garmin Connect and save to a JSON file."""


### PR DESCRIPTION
Hi there, thanks for creating this package, it's great! I can create an issue if needed but this seemed quicker.

I recently tried to onboard to GarminDB. My data stretches back to 2019, and even though garth has some retry behaviour, it wasn't enough. I found that the download of monitoring data would crash out somewhere during a series of ~7k queries with one error or another, at which point all that downloaded data would be lost and I'd need to start again. Eventually it became clear that although the error rate was low - maybe one every few thousand downloads - it was high enough to have a very small chance of actually completing the process.

One attractive way to deal with this would be to retain a partially downloaded state and resume it on the next attempt. But that sounds like effort! Instead this PR just expands greatly upon the default retries. The choice of parameters is fairly arbitrary. You may want to tweak it. But it successfully unblocked me, and I see little downside to a change such as this. It seems worthwhile to retry many times before throwing away thousands of downloads that have taken hours to retrieve!