### PR TITLE
Retry Garmin stat downloads on transient failures

### DIFF
--- a/garmindb/download.py
+++ b/garmindb/download.py
@@ -144,7 +144,18 @@ class Download():
             download_date = date + datetime.timedelta(days=day)
             # always overwrite for yesterday and today since the last download may have been a partial result
             delta = datetime.datetime.now().date() - download_date
-            stat_function(directory, download_date, overwrite or delta.days <= self.download_days_overlap)
+            stat_overwrite = overwrite or delta.days <= self.download_days_overlap
+            for attempt in range(1, 6):
+                try:
+                    stat_function(directory, download_date, stat_overwrite)
+                    break
+                except Exception as e:
+                    if attempt == 5:
+                        root_logger.error("Failed to download %s after %d attempts: %s", download_date, attempt, e)
+                    else:
+                        backoff_seconds = attempt * 5
+                        root_logger.warning("Retrying %s after error on attempt %d/%d: %s", download_date, attempt, 5, e)
+                        time.sleep(backoff_seconds)
             # pause for a second between every page access
             time.sleep(1)
 
@@ -327,8 +338,9 @@ class Download():
         url = f'{self.garmin_connect_hrv_url}/{date_str}'
         try:
             self.save_json_to_file(json_filename, self.garth.connectapi(url), overwrite)
-        except GarthHTTPError as e:
-            root_logger.error("Exception getting daily summary %s", e)
+        except Exception as e:
+            root_logger.error("Exception getting hrv for %s: %s", date_str, e)
+            raise
 
     def get_hrv(self, directory, date, days, overwrite):
         """Download the heart rate variability (HRV) data from Garmin Connect and save to a JSON file."""

--- a/garmindb/download.py
+++ b/garmindb/download.py
@@ -113,7 +113,18 @@ class Download():
             download_date = date + datetime.timedelta(days=day)
             # always overwrite for yesterday and today since the last download may have been a partial result
             delta = datetime.datetime.now().date() - download_date
-            stat_function(directory, download_date, overwrite or delta.days <= self.download_days_overlap)
+            stat_overwrite = overwrite or delta.days <= self.download_days_overlap
+            for attempt in range(1, 6):
+                try:
+                    stat_function(directory, download_date, stat_overwrite)
+                    break
+                except Exception as e:
+                    if attempt == 5:
+                        root_logger.error("Failed to download %s after %d attempts: %s", download_date, attempt, e)
+                    else:
+                        backoff_seconds = attempt * 5
+                        root_logger.warning("Retrying %s after error on attempt %d/%d: %s", download_date, attempt, 5, e)
+                        time.sleep(backoff_seconds)
             # pause for a second between every page access
             time.sleep(1)
 
@@ -296,8 +307,9 @@ class Download():
         url = f'{self.garmin_connect_hrv_url}/{date_str}'
         try:
             self.save_json_to_file(json_filename, self.garmin.connectapi(url), overwrite)
-        except GarminConnectAuthError as e:
-            root_logger.error("Exception getting daily summary %s", e)
+        except Exception as e:
+            root_logger.error("Exception getting hrv for %s: %s", date_str, e)
+            raise
 
     def get_hrv(self, directory, date, days, overwrite):
         """Download the heart rate variability (HRV) data from Garmin Connect and save to a JSON file."""

--- a/test/test_download.py
+++ b/test/test_download.py
@@ -1,0 +1,59 @@
+"""Tests for download retry behavior."""
+
+__author__ = "Tom Goetz"
+__copyright__ = "Copyright Tom Goetz"
+__license__ = "GPL"
+
+import datetime
+import unittest
+from unittest import mock
+
+from garmindb.download import Download
+
+
+class FakeConfig:
+    """Minimal config stub for Download tests."""
+
+    def get_session_file(self):
+        return "/tmp/garth_session"
+
+    def get_garmin_base_domain(self):
+        return "garmin.com"
+
+
+class TestDownload(unittest.TestCase):
+    def setUp(self):
+        self.download = Download(FakeConfig())
+
+    def test_get_stat_retries_until_success(self):
+        attempts = []
+
+        def flaky_stat(directory, day, overwrite):
+            attempts.append((directory, day, overwrite))
+            if len(attempts) < 3:
+                raise RuntimeError("temporary HRV gap")
+
+        start_date = datetime.date(2026, 3, 1)
+        with mock.patch("garmindb.download.time.sleep"):
+            self.download._Download__get_stat(flaky_stat, "/tmp/hrv", start_date, 1, False)
+
+        self.assertEqual(len(attempts), 3)
+        self.assertEqual(attempts[0][0], "/tmp/hrv")
+        self.assertEqual(attempts[0][1], start_date)
+
+    def test_get_stat_stops_after_five_failures(self):
+        attempts = []
+
+        def always_fail(directory, day, overwrite):
+            attempts.append((directory, day, overwrite))
+            raise RuntimeError("persistent HRV gap")
+
+        start_date = datetime.date(2026, 3, 1)
+        with mock.patch("garmindb.download.time.sleep"):
+            self.download._Download__get_stat(always_fail, "/tmp/hrv", start_date, 1, False)
+
+        self.assertEqual(len(attempts), 5)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

This change retries daily Garmin stat downloads when transient API failures occur.

In particular, HRV downloads can fail intermittently for specific dates. Before this change, those failures were logged and then skipped, which could leave gaps in downloaded data. With this patch, stat downloads retry up to 5 times with a short backoff before giving up.

## Changes

- add retry logic in `Download.__get_stat`
- make `__get_hrv_day` re-raise fetch failures so they participate in the retry loop
- add a regression test covering retry-until-success and stop-after-five-failures behavior

## Why

I hit intermittent HRV download failures on specific dates. Retrying the stat fetch resolves transient failures without requiring manual reruns and makes the HRV import path more robust.

## Testing

Ran:

```bash
PYTHONPATH=/home/adam/GarminDB /home/adam/GarminDB/.venv/bin/python /home/adam/GarminDB/test/test_download.py
```
