### PR TITLE
Fix off-by-one in latest download date range

### DIFF
--- a/scripts/garmindb_cli.py
+++ b/scripts/garmindb_cli.py
@@ -71,7 +71,7 @@ class GarminDbMain():
                 logger.info("Downloading latest %s data from: %s", stat_name, last_ts)
                 last_ts_date_date = last_ts.date() if isinstance(last_ts, datetime.datetime) else last_ts
                 date = last_ts_date_date - datetime.timedelta(days=1)
-                days = (datetime.date.today() - date).days
+                days = (datetime.date.today() - date).days + 1
         else:
             date, days = self.gc_config.stat_start_date(stat_name)
             days = min((datetime.date.today() - date).days, days)


### PR DESCRIPTION
## Summary

When using the `-l` (latest) flag, today's data is never downloaded due to an off-by-one error in the date range calculation.

**Example:** If the last DB entry is April 14 and today is April 15:
- `date` = April 13 (one day before latest entry)
- `days` = `(April 15 - April 13).days` = 2
- `range(0, 2)` → downloads April 13 and April 14
- **April 15 is skipped**

This affects all stats (sleep, HRV, rhr, weight, monitoring) when using `--latest`. The fix adds `+ 1` to include today in the download range.

## Test plan

- Run `garmindb_cli.py --hrv -s -d -i -l` and verify today's sleep/HRV data appears in the database
- Confirmed working locally — today's data now syncs correctly