### PR TITLE
feat(auth)!: switch login from garth to python-garminconnect

### DIFF
--- a/garmindb/download.py
+++ b/garmindb/download.py
@@ -13,11 +13,11 @@ import time
 import tempfile
 import zipfile
 import json
-from garth import Client as GarthClient
-from garth.exc import GarthHTTPError, GarthException
 from tqdm import tqdm
 
 import fitfile.conversions as conversions
+
+from .garmin_connect_auth_adapter import GarminConnectAuthAdapter, GarminConnectAuthError
 
 
 logger = logging.getLogger(__file__)
@@ -52,53 +52,23 @@ class Download():
         """Create a new Download class instance."""
         logger.debug("__init__")
         self.gc_config = gc_config
-        self.garth_session_file = self.gc_config.get_session_file()
-        self.garth = GarthClient()
-        self.garth.configure(domain=self.gc_config.get_garmin_base_domain())
-
-    def __resume_session(self):
-        if os.path.isfile(self.garth_session_file):
-            root_logger.info("load session from %s", self.garth_session_file)
-            with open(self.garth_session_file, "r", encoding="utf-8") as file:
-                self.garth.loads(file.read())
-                return True
-        else:
-            root_logger.info("session file %s not found", self.garth_session_file)
-        return False
-
-    def __save_session(self):
-        root_logger.info("save session to %s", self.garth_session_file)
-        with open(self.garth_session_file, "w", encoding="utf-8") as file:
-            file.write(self.garth.dumps())
-
-    def __login(self):
-        username = self.gc_config.get_user()
-        password = self.gc_config.get_password()
-        if not username or not password:
-            print("Missing config: need username and password. Edit GarminConnectConfig.json.")
-            return
-
-        logger.debug("login: %s %s", username, password)
-        self.garth.login(username, password)
-        self.__save_session()
+        self.garmin = GarminConnectAuthAdapter(self.gc_config)
 
     def login(self):
-        """Use garth to resume to Garmin Connect session if possible, otherwise login."""
-        if not self.__resume_session():
-            self.__login()
-
+        """Authenticate to Garmin Connect."""
         try:
-            self.garth.username
-        except GarthException:
-            self.__login()
+            self.garmin.login()
+        except GarminConnectAuthError as e:
+            root_logger.error("login failed: %s", e)
+            return False
 
         profile_dir = self.gc_config.get_fit_files_dir()
-        self.save_json_to_file(f'{profile_dir}/social-profile', self.garth.profile)
-        self.save_json_to_file(f'{profile_dir}/user-settings', self.garth.connectapi(f'{self.garmin_connect_user_profile_url}/user-settings'), True)
-        self.save_json_to_file(f'{profile_dir}/personal-information', self.garth.connectapi(f'{self.garmin_connect_user_profile_url}/personal-information'), True)
+        self.save_json_to_file(f'{profile_dir}/social-profile', self.garmin.profile)
+        self.save_json_to_file(f'{profile_dir}/user-settings', self.garmin.connectapi(f'{self.garmin_connect_user_profile_url}/user-settings'), True)
+        self.save_json_to_file(f'{profile_dir}/personal-information', self.garmin.connectapi(f'{self.garmin_connect_user_profile_url}/personal-information'), True)
 
-        self.display_name = self.garth.profile['displayName']
-        self.full_name = self.garth.profile['fullName']
+        self.display_name = self.garmin.display_name
+        self.full_name = self.garmin.full_name
         root_logger.info("login: %s (%s)", self.full_name, self.display_name)
         return True
 
@@ -134,10 +104,9 @@ class Download():
         exists = os.path.isfile(filename)
         if not exists or overwrite:
             logger.debug("%s %s", 'Overwriting' if exists else 'Saving', filename)
-            response = self.garth.get("connectapi", url, api=True)
+            response = self.garmin.download(url)
             with open(filename, 'wb') as file:
-                for chunk in response:
-                    file.write(chunk)
+                file.write(response)
 
     def __get_stat(self, stat_function, directory, date, days, overwrite):
         for day in tqdm(range(0, days), unit='days'):
@@ -158,8 +127,8 @@ class Download():
         url = f'{self.garmin_connect_daily_summary_url}/{self.display_name}'
         json_filename = f'{directory_func(date.year)}/daily_summary_{date_str}'
         try:
-            self.save_json_to_file(json_filename, self.garth.connectapi(url, params=params), overwrite)
-        except GarthHTTPError as e:
+            self.save_json_to_file(json_filename, self.garmin.connectapi(url, params=params), overwrite)
+        except GarminConnectAuthError as e:
             root_logger.error("Exception getting daily summary: %s", e)
 
     def get_daily_summaries(self, directory_func, date, days, overwrite):
@@ -173,7 +142,7 @@ class Download():
         url = f'{self.garmin_connect_download_service_url}/wellness/{date.strftime("%Y-%m-%d")}'
         try:
             self.save_binary_file(zip_filename, url)
-        except GarthHTTPError as e:
+        except GarminConnectAuthError as e:
             root_logger.error("Exception getting daily summary: %s", e)
 
     def get_monitoring(self, directory_func, date, days):
@@ -197,8 +166,8 @@ class Download():
         }
         json_filename = f'{directory}/weight_{date_str}'
         try:
-            self.save_json_to_file(json_filename, self.garth.connectapi(self.garmin_connect_weight_url, params=params), overwrite)
-        except GarthHTTPError as e:
+            self.save_json_to_file(json_filename, self.garmin.connectapi(self.garmin_connect_weight_url, params=params), overwrite)
+        except GarminConnectAuthError as e:
             root_logger.error("Exception getting daily summary: %s", e)
 
     def get_weight(self, directory, date, days, overwrite):
@@ -214,8 +183,8 @@ class Download():
             "limit" : str(count)
         }
         try:
-            return self.garth.connectapi(self.garmin_connect_activity_search_url, params=params)
-        except GarthHTTPError as e:
+            return self.garmin.connectapi(self.garmin_connect_activity_search_url, params=params)
+        except GarminConnectAuthError as e:
             root_logger.error("Exception getting activity summary: %s", e)
 
     def __save_activity_details(self, directory, activity_id_str, overwrite):
@@ -224,8 +193,8 @@ class Download():
         try:
             url = f'{self.garmin_connect_activity_service_url}/{activity_id_str}'
             self.save_json_to_file(
-                json_filename, self.garth.connectapi(url), overwrite)
-        except GarthHTTPError as e:
+                json_filename, self.garmin.connectapi(url), overwrite)
+        except GarminConnectAuthError as e:
             root_logger.error("Exception getting daily summary %s", e)
 
     def __save_activity_file(self, activity_id_str):
@@ -234,7 +203,7 @@ class Download():
         url = f'{self.garmin_connect_download_service_url}/activity/{activity_id_str}'
         try:
             self.save_binary_file(zip_filename, url)
-        except GarthHTTPError as e:
+        except GarminConnectAuthError as e:
             root_logger.error("Exception downloading activity file: %s", e)
 
     def get_activities(self, directory, count, overwrite=False):
@@ -266,8 +235,8 @@ class Download():
         try:
             url = f'{self.garmin_connect_activity_service_url}/activityTypes'
             self.save_json_to_file(
-                json_filename, self.garth.connectapi(url), overwrite)
-        except GarthHTTPError as e:
+                json_filename, self.garmin.connectapi(url), overwrite)
+        except GarminConnectAuthError as e:
             root_logger.error("Exception getting activity types: %s", e)
 
     def __get_sleep_day(self, directory, date, overwrite=False):
@@ -278,8 +247,8 @@ class Download():
         }
         url = f'{self.garmin_connect_sleep_daily_url}/{self.display_name}'
         try:
-            self.save_json_to_file(json_filename, self.garth.connectapi(url, params=params), overwrite)
-        except GarthHTTPError as e:
+            self.save_json_to_file(json_filename, self.garmin.connectapi(url, params=params), overwrite)
+        except GarminConnectAuthError as e:
             root_logger.error("Exception getting daily summary: %s", e)
 
     def get_sleep(self, directory, date, days, overwrite):
@@ -297,9 +266,9 @@ class Download():
         }
         url = f'{self.garmin_connect_rhr}/{self.display_name}'
         try:
-            self.save_json_to_file(json_filename, self.garth.connectapi(
+            self.save_json_to_file(json_filename, self.garmin.connectapi(
                 url, params=params), overwrite)
-        except GarthHTTPError as e:
+        except GarminConnectAuthError as e:
             root_logger.error("Exception getting daily summary %s", e)
 
     def get_rhr(self, directory, date, days, overwrite):
@@ -312,8 +281,8 @@ class Download():
         json_filename = f'{directory_func(day.year)}/hydration_{date_str}'
         url = f'{self.garmin_connect_daily_hydration_url}/{date_str}'
         try:
-            self.save_json_to_file(json_filename, self.garth.connectapi(url), overwrite)
-        except GarthHTTPError as e:
+            self.save_json_to_file(json_filename, self.garmin.connectapi(url), overwrite)
+        except GarminConnectAuthError as e:
             root_logger.error("Exception getting hydration: %s", e)
 
     def get_hydration(self, directory_func, date, days, overwrite):
@@ -326,8 +295,8 @@ class Download():
         json_filename = f'{directory}/hrv_{date_str}'
         url = f'{self.garmin_connect_hrv_url}/{date_str}'
         try:
-            self.save_json_to_file(json_filename, self.garth.connectapi(url), overwrite)
-        except GarthHTTPError as e:
+            self.save_json_to_file(json_filename, self.garmin.connectapi(url), overwrite)
+        except GarminConnectAuthError as e:
             root_logger.error("Exception getting daily summary %s", e)
 
     def get_hrv(self, directory, date, days, overwrite):

--- a/garmindb/garmin_connect_auth_adapter.py
+++ b/garmindb/garmin_connect_auth_adapter.py
@@ -1,7 +1,7 @@
 """Adapter around python-garminconnect authentication."""
 
-__author__ = "Tom Goetz"
-__copyright__ = "Copyright Tom Goetz"
+__author__ = "Ilya Verchenko"
+__copyright__ = "Copyright Ilya Verchenko"
 __license__ = "GPL"
 
 import logging

--- a/garmindb/garmin_connect_auth_adapter.py
+++ b/garmindb/garmin_connect_auth_adapter.py
@@ -1,0 +1,116 @@
+"""Adapter around python-garminconnect authentication."""
+
+__author__ = "Tom Goetz"
+__copyright__ = "Copyright Tom Goetz"
+__license__ = "GPL"
+
+import logging
+import os
+
+from garminconnect import (
+    GarminConnectAuthenticationError,
+    GarminConnectConnectionError,
+    GarminConnectTooManyRequestsError,
+)
+
+
+logger = logging.getLogger(__file__)
+
+
+_GARMINCONNECT_ERRORS = (
+    GarminConnectAuthenticationError,
+    GarminConnectConnectionError,
+    GarminConnectTooManyRequestsError,
+)
+
+
+class GarminConnectAuthError(Exception):
+    """Garmin Connect authentication or request failed."""
+
+
+class GarminConnectAuthAdapter:
+    """Small GarminDB boundary around garminconnect.Garmin."""
+
+    def __init__(self, gc_config, garmin_factory=None, mfa_prompt=None):
+        """Create a new Garmin Connect auth adapter."""
+        self.gc_config = gc_config
+        self.garmin_factory = garmin_factory or self.__default_garmin_factory
+        self.mfa_prompt = mfa_prompt or self.__prompt_mfa
+        self.client = None
+        self.profile = None
+        self.display_name = None
+        self.full_name = None
+
+    @staticmethod
+    def __default_garmin_factory(**kwargs):
+        from garminconnect import Garmin
+
+        return Garmin(**kwargs)
+
+    @staticmethod
+    def __prompt_mfa():
+        return input("MFA code: ").strip()
+
+    def __is_cn_domain(self):
+        return self.gc_config.get_garmin_base_domain() == "garmin.cn"
+
+    def __token_store_file(self):
+        return self.gc_config.get_token_store_file()
+
+    def login(self):
+        """Authenticate using cached DI tokens first, then configured credentials."""
+        token_store_file = self.__token_store_file()
+        if os.path.isfile(token_store_file):
+            try:
+                self.client = self.garmin_factory(is_cn=self.__is_cn_domain())
+                self.client.login(token_store_file)
+                self.__load_profile()
+                return True
+            except _GARMINCONNECT_ERRORS as e:
+                logger.warning(
+                    "cached Garmin Connect token login failed for %s: %s; falling back to credential login",
+                    token_store_file, e,
+                )
+                self.client = None
+
+        username = self.gc_config.get_user()
+        password = self.gc_config.get_password()
+        if not username or not password:
+            raise GarminConnectAuthError("Missing config: need username and password. Edit GarminConnectConfig.json.")
+
+        try:
+            self.client = self.garmin_factory(
+                email=username,
+                password=password,
+                is_cn=self.__is_cn_domain(),
+                prompt_mfa=self.mfa_prompt,
+            )
+            self.client.login(token_store_file)
+            self.__load_profile()
+            return True
+        except _GARMINCONNECT_ERRORS as e:
+            self.client = None
+            raise GarminConnectAuthError(f"Garmin Connect login failed: {e}") from e
+
+    def __load_profile(self):
+        self.profile = self.client.connectapi("/userprofile-service/socialProfile")
+        self.display_name = self.profile.get("displayName", getattr(self.client, "display_name", None))
+        self.full_name = self.profile.get("fullName", getattr(self.client, "full_name", None))
+
+    def connectapi(self, path, **kwargs):
+        """Call a Garmin Connect JSON endpoint."""
+        if self.client is None:
+            raise GarminConnectAuthError("Garmin Connect client is not authenticated.")
+        try:
+            return self.client.connectapi(path, **kwargs)
+        except _GARMINCONNECT_ERRORS as e:
+            raise GarminConnectAuthError(f"Garmin Connect API request failed: {e}") from e
+
+    def download(self, path, **kwargs):
+        """Download binary content from Garmin Connect."""
+        if self.client is None:
+            raise GarminConnectAuthError("Garmin Connect client is not authenticated.")
+        try:
+            return self.client.download(path, **kwargs)
+        except _GARMINCONNECT_ERRORS as e:
+            raise GarminConnectAuthError(f"Garmin Connect download failed: {e}") from e

--- a/garmindb/garmin_connect_config_manager.py
+++ b/garmindb/garmin_connect_config_manager.py
@@ -58,9 +58,9 @@ class GarminConnectConfigManager(JsonConfig):
             os.makedirs(dir)
         return dir
 
-    def get_session_file(self):
-        """Return the path to the session file."""
-        return self.config_dir + os.sep + 'garth_session'
+    def get_token_store_file(self):
+        """Return the path to the Garmin Connect DI OAuth2 token store."""
+        return self.config_dir + os.sep + 'garmin_tokens.json'
 
     def get_db_type(self):
         """Return the type (SQLite, MySQL, etc) of database that is configured."""

--- a/garmindb/version_info.py
+++ b/garmindb/version_info.py
@@ -5,7 +5,7 @@ __copyright__ = "Copyright Tom Goetz"
 __license__ = "GPL"
 
 
-python_required = (3, 10, 0)
+python_required = (3, 12, 0)
 dev_python_required = (3, 13, 9)
 python_tested = (3, 14, 2)
 version_info = (3, 7, 0)

--- a/pyproject.toml.in
+++ b/pyproject.toml.in
@@ -5,14 +5,12 @@ description = "Garmin Connect download and analysis"
 authors = [
     {name = "Tom Goetz"},
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 readme = "README.md"
 license = {text = "GPL"}
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Operating System :: MacOS :: MacOS X",

--- a/requirements.in
+++ b/requirements.in
@@ -2,7 +2,7 @@ sqlalchemy~=2.0.46
 python-dateutil
 cached-property
 tqdm
-garth>=0.6.3
+garminconnect>=0.3.3
 fitfile>=1.2.0
 tcxfile>=1.0.4
 idbutils>=1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ SQLAlchemy==2.0.46
 python-dateutil==2.9.0.post0
 cached-property==2.0.1
 tqdm==4.67.1
-garth==0.6.3
+garminconnect==0.3.3
 fitfile>=1.2.0
 tcxfile>=1.0.4
 idbutils>=1.1.0

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,8 @@ setup(name=module_name, version=module_version, author='Tom Goetz',
       include_package_data=True,
       classifiers=[
           'License :: OSI Approved :: GNU General Public License v2 (GPLv2)',
-          "Programming Language :: Python :: 3",
+          "Programming Language :: Python :: 3.12",
+          "Programming Language :: Python :: 3.13",
           "Operating System :: OS Independent"
       ],
-      python_requires=">=3.0")
+      python_requires=">=3.12")

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -43,6 +43,11 @@ class TestConfig(unittest.TestCase):
         monitoring_dir = self.gc_config.get_monitoring_dir(year)
         self.assertEqual(monitoring_dir, expected_monitoring_dir, f'actual {monitoring_dir} expected {expected_monitoring_dir}')
 
+    def test_token_store_file(self):
+        expected_token_store_file = self.homedir + os.sep + '.GarminDb' + os.sep + 'garmin_tokens.json'
+        token_store_file = self.gc_config.get_token_store_file()
+        self.assertEqual(token_store_file, expected_token_store_file, f'actual {token_store_file} expected {expected_token_store_file}')
+
     def test_db(self):
         db_params = self.gc_config.get_db_params()
         expect_db_type = 'sqlite'

--- a/test/test_download_auth_adapter.py
+++ b/test/test_download_auth_adapter.py
@@ -1,7 +1,7 @@
 """Test Download integration with the Garmin Connect auth adapter."""
 
-__author__ = "Tom Goetz"
-__copyright__ = "Copyright Tom Goetz"
+__author__ = "Ilya Verchenko"
+__copyright__ = "Copyright Ilya Verchenko"
 __license__ = "GPL"
 
 import json

--- a/test/test_download_auth_adapter.py
+++ b/test/test_download_auth_adapter.py
@@ -1,0 +1,106 @@
+"""Test Download integration with the Garmin Connect auth adapter."""
+
+__author__ = "Tom Goetz"
+__copyright__ = "Copyright Tom Goetz"
+__license__ = "GPL"
+
+import json
+import datetime
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from garmindb.download import Download
+
+
+class FakeConfig:
+    def __init__(self, fit_files_dir):
+        self.fit_files_dir = fit_files_dir
+
+    def get_fit_files_dir(self):
+        return self.fit_files_dir
+
+
+class FakeAdapter:
+    instances = []
+
+    def __init__(self, _gc_config):
+        self.profile = {"displayName": "display", "fullName": "Full Name"}
+        self.display_name = "display"
+        self.full_name = "Full Name"
+        self.connectapi_calls = []
+        self.download_calls = []
+        FakeAdapter.instances.append(self)
+
+    def login(self):
+        return True
+
+    def connectapi(self, path, **kwargs):
+        self.connectapi_calls.append((path, kwargs))
+        return {"path": path, "kwargs": kwargs}
+
+    def download(self, path):
+        self.download_calls.append(path)
+        return b"binary-data"
+
+
+class TestDownloadAuthAdapter(unittest.TestCase):
+    def setUp(self):
+        FakeAdapter.instances = []
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.config = FakeConfig(self.temp_dir.name)
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def create_download(self):
+        with patch("garmindb.download.GarminConnectAuthAdapter", FakeAdapter):
+            return Download(self.config)
+
+    def test_login_uses_adapter_and_saves_profile_files(self):
+        download = self.create_download()
+
+        self.assertTrue(download.login())
+
+        adapter = FakeAdapter.instances[0]
+        self.assertEqual(download.display_name, "display")
+        self.assertEqual(download.full_name, "Full Name")
+        self.assertEqual(
+            adapter.connectapi_calls,
+            [
+                ("/userprofile-service/userprofile/user-settings", {}),
+                ("/userprofile-service/userprofile/personal-information", {}),
+            ],
+        )
+
+        with open(os.path.join(self.temp_dir.name, "social-profile.json"), encoding="utf-8") as file:
+            self.assertEqual(json.load(file), {"displayName": "display", "fullName": "Full Name"})
+
+    def test_save_binary_file_uses_adapter_download(self):
+        download = self.create_download()
+        filename = os.path.join(self.temp_dir.name, "activity.zip")
+
+        download.save_binary_file(filename, "/download-service/files/activity/123")
+
+        self.assertEqual(FakeAdapter.instances[0].download_calls, ["/download-service/files/activity/123"])
+        with open(filename, "rb") as file:
+            self.assertEqual(file.read(), b"binary-data")
+
+    def test_summary_download_uses_adapter_connectapi(self):
+        download = self.create_download()
+        download.display_name = "display"
+
+        download._Download__get_summary_day(
+            lambda _year: self.temp_dir.name,
+            datetime.date(2024, 1, 2),
+            overwrite=True,
+        )
+
+        path, kwargs = FakeAdapter.instances[0].connectapi_calls[0]
+        self.assertEqual(path, "/usersummary-service/usersummary/daily/display")
+        self.assertEqual(kwargs["params"]["calendarDate"], "2024-01-02")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/test/test_garmin_connect_auth_adapter.py
+++ b/test/test_garmin_connect_auth_adapter.py
@@ -1,0 +1,134 @@
+"""Test Garmin Connect auth adapter."""
+
+__author__ = "Tom Goetz"
+__copyright__ = "Copyright Tom Goetz"
+__license__ = "GPL"
+
+import os
+import tempfile
+import unittest
+
+from garminconnect import GarminConnectAuthenticationError
+
+from garmindb.garmin_connect_auth_adapter import GarminConnectAuthAdapter, GarminConnectAuthError
+
+
+class FakeConfig:
+    def __init__(self, config_dir, user="user@example.com", password="secret", domain="garmin.com"):
+        self.config_dir = config_dir
+        self.user = user
+        self.password = password
+        self.domain = domain
+
+    def get_token_store_file(self):
+        return self.config_dir + os.sep + "garmin_tokens.json"
+
+    def get_garmin_base_domain(self):
+        return self.domain
+
+    def get_user(self):
+        return self.user
+
+    def get_password(self):
+        return self.password
+
+
+class FakeGarmin:
+    instances = []
+
+    def __init__(self, fail_login=False, **kwargs):
+        self.fail_login = fail_login
+        self.kwargs = kwargs
+        self.login_calls = []
+        self.connectapi_calls = []
+        self.download_calls = []
+        FakeGarmin.instances.append(self)
+
+    def login(self, tokenstore):
+        self.login_calls.append(tokenstore)
+        if self.fail_login:
+            raise GarminConnectAuthenticationError("login failed")
+
+    def connectapi(self, path, **kwargs):
+        self.connectapi_calls.append((path, kwargs))
+        if path == "/userprofile-service/socialProfile":
+            return {"displayName": "display", "fullName": "Full Name"}
+        return {"path": path, "kwargs": kwargs}
+
+    def download(self, path, **kwargs):
+        self.download_calls.append((path, kwargs))
+        return b"downloaded"
+
+
+class TestGarminConnectAuthAdapter(unittest.TestCase):
+    def setUp(self):
+        FakeGarmin.instances = []
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.config = FakeConfig(self.temp_dir.name)
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_cached_token_login_uses_token_store_without_credentials(self):
+        token_store_file = self.config.get_token_store_file()
+        with open(token_store_file, "w", encoding="utf-8") as file:
+            file.write("{}")
+
+        adapter = GarminConnectAuthAdapter(self.config, garmin_factory=FakeGarmin)
+
+        self.assertTrue(adapter.login())
+        self.assertEqual(len(FakeGarmin.instances), 1)
+        self.assertEqual(FakeGarmin.instances[0].kwargs, {"is_cn": False})
+        self.assertEqual(FakeGarmin.instances[0].login_calls, [token_store_file])
+        self.assertEqual(adapter.display_name, "display")
+        self.assertEqual(adapter.full_name, "Full Name")
+
+    def test_invalid_cached_token_falls_back_to_credentials(self):
+        token_store_file = self.config.get_token_store_file()
+        with open(token_store_file, "w", encoding="utf-8") as file:
+            file.write("{}")
+
+        def garmin_factory(**kwargs):
+            return FakeGarmin(fail_login=len(FakeGarmin.instances) == 0, **kwargs)
+
+        adapter = GarminConnectAuthAdapter(self.config, garmin_factory=garmin_factory)
+
+        with self.assertLogs(level="WARNING") as captured:
+            self.assertTrue(adapter.login())
+        self.assertEqual(len(FakeGarmin.instances), 2)
+        self.assertEqual(FakeGarmin.instances[1].kwargs["email"], "user@example.com")
+        self.assertEqual(FakeGarmin.instances[1].kwargs["password"], "secret")
+        self.assertEqual(FakeGarmin.instances[1].login_calls, [token_store_file])
+        warnings = [r for r in captured.records if r.levelname == "WARNING"]
+        self.assertTrue(
+            any(token_store_file in r.getMessage() and "falling back to credential login" in r.getMessage() for r in warnings),
+            f"expected WARNING mentioning {token_store_file} and fallback, got {[r.getMessage() for r in warnings]}",
+        )
+
+    def test_missing_credentials_raise_auth_error(self):
+        config = FakeConfig(self.temp_dir.name, user="", password="")
+        adapter = GarminConnectAuthAdapter(config, garmin_factory=FakeGarmin)
+
+        with self.assertRaises(GarminConnectAuthError):
+            adapter.login()
+
+    def test_cn_domain_maps_to_is_cn(self):
+        config = FakeConfig(self.temp_dir.name, domain="garmin.cn")
+        adapter = GarminConnectAuthAdapter(config, garmin_factory=FakeGarmin)
+
+        self.assertTrue(adapter.login())
+        self.assertTrue(FakeGarmin.instances[0].kwargs["is_cn"])
+
+    def test_connectapi_and_download_forward_to_authenticated_client(self):
+        adapter = GarminConnectAuthAdapter(self.config, garmin_factory=FakeGarmin)
+        adapter.login()
+
+        self.assertEqual(
+            adapter.connectapi("/example", params={"a": "b"}),
+            {"path": "/example", "kwargs": {"params": {"a": "b"}}},
+        )
+        self.assertEqual(adapter.download("/file"), b"downloaded")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/test/test_garmin_connect_auth_adapter.py
+++ b/test/test_garmin_connect_auth_adapter.py
@@ -1,7 +1,7 @@
 """Test Garmin Connect auth adapter."""
 
-__author__ = "Tom Goetz"
-__copyright__ = "Copyright Tom Goetz"
+__author__ = "Ilya Verchenko"
+__copyright__ = "Copyright Ilya Verchenko"
 __license__ = "GPL"
 
 import os


### PR DESCRIPTION
Replace deprecated garth session handling with a python-garminconnect auth adapter.

Update the token store path, dependency set, and Python version metadata, and add tests for adapter login flows plus Download integration.

Fixes #311

BREAKING CHANGE: GarminDB now requires Python 3.12+ and uses garminconnect token storage at garmin_tokens.json instead of the previous garth session file.