### PR TITLE
Fix off-by-one preventing download of today's data (#264)

### DIFF
--- a/garmindb/garmin_connect_config_manager.py
+++ b/garmindb/garmin_connect_config_manager.py
@@ -221,7 +221,7 @@ class GarminConnectConfigManager(JsonConfig):
             # If still nothing, default to 20 days ago
             start_date = datetime.datetime.now().date() - datetime.timedelta(days=20)
         end_date = self.get_node_value_default('data', stat_type + '_end_date', datetime.datetime.now().date())
-        days = (end_date - start_date).days
+        days = (end_date - start_date).days + 1
         return (start_date, days)
 
     def device_mount_dir(self):

--- a/scripts/garmindb_cli.py
+++ b/scripts/garmindb_cli.py
@@ -71,10 +71,10 @@ class GarminDbMain():
                 logger.info("Downloading latest %s data from: %s", stat_name, last_ts)
                 last_ts_date_date = last_ts.date() if isinstance(last_ts, datetime.datetime) else last_ts
                 date = last_ts_date_date - datetime.timedelta(days=1)
-                days = (datetime.date.today() - date).days
+                days = (datetime.date.today() - date).days + 1
         else:
             date, days = self.gc_config.stat_start_date(stat_name)
-            days = min((datetime.date.today() - date).days, days)
+            days = min((datetime.date.today() - date).days + 1, days)
             logger.info("Downloading all %s data from: %s [%d]", stat_name, date, days)
         if date is None or days is None:
             logger.error("Missing config: need %s_start_date and download_days. Edit GarminConnectConfig.py.", stat_name)


### PR DESCRIPTION
The download date range always stopped at yesterday, so checking today's sleep or stats required waiting until the next day.

range(0, (today - date).days) excluded today because both range() and timedelta.days are end-exclusive. Adding + 1 to the three date-delta calculations makes the date range inclusive of today.